### PR TITLE
Corrected list of mandatory fields

### DIFF
--- a/src/main/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTask.groovy
+++ b/src/main/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTask.groovy
@@ -20,7 +20,7 @@ class SpawnProcessTask extends DefaultTask {
     @TaskAction
     void spawn(){
         if(!(command && ready)) {
-            throw new GradleException("Ensure that mandatory fields command, directory and ready are set.")
+            throw new GradleException("Ensure that mandatory fields command and ready are set.")
         }
 
         def pidFile = new File(directory, LOCK_FILE)


### PR DESCRIPTION
Since the directory field defaults to '.', the error message should not include this in the list of mandatory fields as the plugin would pick up the default.
