### PR TITLE
Optional "spawnName" task property has been added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,14 @@ Add the following to your `build.gradle`:
 	task startServer(type: SpawnProcessTask, dependsOn: 'assemble') {
 		command "java -jar ${projectDir}/build/libs/zim-service.jar"
 		ready 'Started Application'
+		spawnName 'app-server' // optional
+		directory '.pidfiles' // optional
 	}
 
-	task stopServer(type: KillProcessTask)
+	task stopServer(type: KillProcessTask) {
+	  spawnName 'app-server' // optional
+	  directory '.pidfiles' // optional
+	}
 
 The `startServer` task is used for starting the process.
 
@@ -35,7 +40,9 @@ The command line passed into the `command` method is typically a blocking proces
 
 Once the build draws to a close, the `stopServer` task is then used to gracefully shut down the server process.
 
+Optionally, it's possible to provide names for tasks using `spawnName` and specify a directory for PID files in order to be able to spawn several tasks in parallel. Default values for the `spawnName` and `directory` are empty name and `.` (current directory), accordingly.
+
 ###PID File
 
 The `SpawnProcessTask` will automatically deposit a `.pid.lock` file in the working directory. This contains the PID of the running process.
-The `KillProcessTask` will read this lock file, kill the process gracefully, and remove the file.
+The `KillProcessTask` will read this lock file, kill the process gracefully, and remove the file. In case of spawning several tasks, files will look like `.task-name.pid.lock`.

--- a/src/main/groovy/com/wiredforcode/gradle/spawn/DefaultSpawnTask.groovy
+++ b/src/main/groovy/com/wiredforcode/gradle/spawn/DefaultSpawnTask.groovy
@@ -3,10 +3,13 @@ package com.wiredforcode.gradle.spawn
 import org.gradle.api.DefaultTask
 
 class DefaultSpawnTask extends DefaultTask {
-    String pidLockFileName = '.pid.lock'
+
+    private static final String PID_LOCK_SUFFIX = '.pid.lock'
+
+    String spawnName
     String directory = '.'
 
     File getPidFile() {
-        return new File(directory, pidLockFileName)
+        return new File(directory, '.' + spawnName + PID_LOCK_SUFFIX)
     }
 }

--- a/src/test/groovy/com/wiredforcode/gradle/spawn/KillProcessTaskSpec.groovy
+++ b/src/test/groovy/com/wiredforcode/gradle/spawn/KillProcessTaskSpec.groovy
@@ -5,8 +5,6 @@ import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
-import static com.wiredforcode.gradle.spawn.SpawnProcessTask.LOCK_FILE
-
 class KillProcessTaskSpec extends Specification {
     Project project
     SpawnProcessTask spawnTask
@@ -95,14 +93,16 @@ class KillProcessTaskSpec extends Specification {
         killTask.directory == directoryPath
     }
 
-    void "should allow an override of the pid file name"() {
+    void "should allow the task to be named"() {
         given:
+        def spawnName = "awesome-task"
         killTask
 
         when:
-        killTask.pidLockFileName = '.new.pid.lock'
+        killTask.spawnName = spawnName
 
         then:
-        killTask.pidLockFileName == '.new.pid.lock'
+        killTask.spawnName == spawnName
+        killTask.getPidFile().name == '.' + spawnName + '.pid.lock'
     }
 }

--- a/src/test/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTaskSpec.groovy
+++ b/src/test/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTaskSpec.groovy
@@ -46,11 +46,11 @@ class SpawnProcessTaskSpec extends Specification {
         task.getPidFile().exists()
     }
 
-    void "should allow the name of the pid lock file to be overriden"(){
+    void "should allow the task to be named"(){
         given:
         def command = './process.sh'
         def ready = 'It is done...'
-        def pidLockFileName = ".new.pid.lock"
+        def spawnName = "awesome-task"
 
         and:
         setExecutableProcess("process.sh")
@@ -59,13 +59,13 @@ class SpawnProcessTaskSpec extends Specification {
         task.command = command
         task.ready = ready
         task.directory = directory.toString()
-        task.pidLockFileName = pidLockFileName
+        task.spawnName = spawnName
 
         when:
         task.spawn()
 
         then:
-        task.getPidFile().name == pidLockFileName
+        task.getPidFile().name == '.' + spawnName + '.pid.lock';
     }
 
     void "should check if pid file already exists"() {


### PR DESCRIPTION
 * It's possible to name SpawnProcess* and KillProcess* tasks in order to be able to spawn several tasks in parallel;
 * Overridable name of a PID file has been removed due to some resulted source code modifications in compiled plugin which produce "static final" field for PID file.

I decided to provide names for tasks when found that PID file overriding doesn't work at all in one of my projects. `SpawnProcessTask` just didn't have that property. I believe that having named tasks is a bit convenient case.
<div style="display: flex;">
<img src="https://cloud.githubusercontent.com/assets/1304708/14944184/2e397f44-0fec-11e6-8b0c-dbb6e9bc6f9f.png" width="128">
<img src="https://cloud.githubusercontent.com/assets/1304708/14944185/329929e0-0fec-11e6-9681-0726ab29b851.png" width="128">
</div>