### PR TITLE
dont block on read inputstream when app already identified as succesf…

### DIFF
--- a/src/main/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTask.groovy
+++ b/src/main/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTask.groovy
@@ -61,7 +61,7 @@ class SpawnProcessTask extends DefaultSpawnTask {
         def line
         def reader = new BufferedReader(new InputStreamReader(process.getInputStream()))
         boolean isReady = false
-        while ((line = reader.readLine()) != null && !isReady) {
+        while (!isReady && (line = reader.readLine()) != null) {
             logger.quiet line
             runOutputActions(line)
             if (line.contains(ready)) {


### PR DESCRIPTION
…ul started

with this change I'm able to correctly run and stop a ratpack app.