### PR TITLE
KillProcess Task updated to exit gracefully, when the server is not running

### DIFF
--- a/src/main/groovy/com/wiredforcode/gradle/spawn/KillProcessTask.groovy
+++ b/src/main/groovy/com/wiredforcode/gradle/spawn/KillProcessTask.groovy
@@ -1,13 +1,15 @@
 package com.wiredforcode.gradle.spawn
 
-import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 
 class KillProcessTask extends DefaultSpawnTask {
     @TaskAction
     void kill() {
         def pidFile = getPidFile()
-        if(!pidFile.exists()) throw new GradleException("No server running!")
+        if(!pidFile.exists()) {
+            logger.quiet "No server running!"
+            return
+        }
 
         def pid = pidFile.text
         def process = "kill $pid".execute()

--- a/src/test/groovy/com/wiredforcode/gradle/spawn/KillProcessTaskSpec.groovy
+++ b/src/test/groovy/com/wiredforcode/gradle/spawn/KillProcessTaskSpec.groovy
@@ -59,7 +59,7 @@ class KillProcessTaskSpec extends Specification {
         assert directory.deleteDir()
     }
 
-    void "should explode if no pid file exists"() {
+    void "should exit gracefully, if the server is not running"() {
         given:
         def directoryPath = directory.toString()
 
@@ -70,7 +70,7 @@ class KillProcessTaskSpec extends Specification {
         killTask.kill()
 
         then:
-        thrown GradleException
+        noExceptionThrown()
     }
 
     void "should set current directory as default for directory field"() {


### PR DESCRIPTION
I didn't quite understand the necessity of throwing an exception if there was no server running. Ideally the task should just log a message and exit. 

@marc0der - Could you please review? 