### PR TITLE
Adds configuration to proceed if pidFile exists.

### DIFF
--- a/src/main/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTask.groovy
+++ b/src/main/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTask.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.tasks.TaskAction
 class SpawnProcessTask extends DefaultSpawnTask {
     String command
     String ready
+    boolean strict = true;
     List<Closure> outputActions = new ArrayList<Closure>()
 
     @Input
@@ -31,10 +32,16 @@ class SpawnProcessTask extends DefaultSpawnTask {
         }
 
         def pidFile = getPidFile()
-        if (pidFile.exists()) throw new GradleException("Server already running!")
-
-        def process = buildProcess(directory, command)
-        waitToProcessReadyOrClosed(process)
+        if (pidFile.exists()) {
+            if (strict) {
+                throw new GradleException("$command already running!")
+            } else {
+                logger.quiet "$command already running; proceeding."
+            }
+        } else {
+            def process = buildProcess(directory, command)
+            waitToProcessReadyOrClosed(process)
+        }
     }
 
     private void waitToProcessReadyOrClosed(Process process) {

--- a/src/test/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTaskSpec.groovy
+++ b/src/test/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTaskSpec.groovy
@@ -82,6 +82,33 @@ class SpawnProcessTaskSpec extends Specification {
         thrown GradleException
     }
 
+    void "should allow for pid file already existing if strict mode is disabled"() {
+        given:
+        def command = './process.sh'
+
+        and:
+        setExecutableProcess("process.sh")
+
+        and:
+        task.command = command
+        task.ready =  'It is done...'
+        task.directory = directory.toString()
+        task.strict = false
+
+        and:
+        StringBuilder outputBuilder = new StringBuilder()
+        task.withOutput { outputBuilder.append("$it\n") }
+
+        and:
+        task.getPidFile().createNewFile()
+
+        when:
+        task.spawn()
+
+        then:
+        outputBuilder.toString().isEmpty()
+    }
+
     void "should enforce mandatory command field"() {
         given:
         task.directory = directory.toString()


### PR DESCRIPTION
    - Fixes #27
    - If the process was killed but the pidFile was not deleted, this
      will proceed without executing command (silent failure).
    - Defaults to previous behavior (fail if pidFile exists)
    - Also changes "Server" to "$command" in exception message.