### PR TITLE
Use log file to avoid output buffer deadlocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,18 @@ It is also possible to set the name of the pid file allowing more than one proce
 		ready 'Started Application'
 		pidLockFileName '.other.pid.lock'
 	}
+
+###Log File
+
+The `SpawnProcessTask` works by directly reading the output stream of the child process it starts, looking for the ready statement. 
+If you specify a `logFileName` it will instead route the output stream to that file and then tail that file looking for the ready statement.
+This is very useful for long lived processes that generate lots of output and would otherwise deadlock (see http://stackoverflow.com/questions/3285408/java-processbuilder-resultant-process-hangs#answer-3285479)
+
+The log file will be removed by the `SpawnProcessTask` if it exists before spawning the process, effectively truncating it.
+
+	task startServer(type: SpawnProcessTask) {
+		command "java -jar someScriptHere.sh"
+		ready 'Started Application'
+		pidLockFileName '.other.pid.lock'
+		logFileName = 'myServerLog.txt'
+	}

--- a/src/test/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTaskSpec.groovy
+++ b/src/test/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTaskSpec.groovy
@@ -46,6 +46,70 @@ class SpawnProcessTaskSpec extends Specification {
         task.getPidFile().exists()
     }
 
+    void "should property start process when using log file"() {
+        given:
+        def command = './process.sh'
+        def ready = 'It is done...'
+
+        and:
+        setExecutableProcess("process.sh")
+
+        and:
+        task.command = command
+        task.ready = ready
+        task.directory = directory.toString()
+        task.logFileName = "log.txt"
+
+        when:
+        task.spawn()
+
+        then:
+        task.getPidFile().exists()
+    }
+
+    void "should record all output in log file when using a log file"() {
+        given:
+        def command = './process.sh'
+        def ready = 'It is done...'
+
+        and:
+        setExecutableProcess("process.sh")
+
+        and:
+        task.command = command
+        task.ready = ready
+        task.directory = directory.toString()
+        task.logFileName = "log.txt"
+
+        when:
+        task.spawn()
+
+        then:
+        task.logFile.text.startsWith("Starting...\nIt is done...\n")
+    }
+
+    void "should remove log file before starting process"() {
+        given:
+        def command = './process.sh'
+        def ready = 'It is done...'
+
+        and:
+        setExecutableProcess("process.sh")
+
+        and:
+        task.command = command
+        task.ready = ready
+        task.directory = directory.toString()
+        task.logFileName = "log.txt"
+        task.logFile.text = "Remove me"
+
+        when:
+        task.spawn()
+
+        then:
+        task.logFile.text.startsWith("Starting...\nIt is done...\n")
+    }
+
     void "should allow the name of the pid lock file to be overriden"() {
         given:
         def command = './process.sh'


### PR DESCRIPTION
This would resolve issue #30.

This uses a ProcessBuilder API introduced in Java 7, but that shouldn't matter since gradle itself requires 7+.

This pull request allows one to optionally redirect the process output to a log file to avoid output buffer issues once the process has been started and the output stops being read. A different approach would be to have a background thread keep reading the output even after the process is ready, but that solution is limited to when the gradle process itself is still running, sort of defeating the purpose of the plugin.