### PR TITLE
Multiple fixes and enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 .pid.lock
 build
 gradle-spawn-plugin.iml
+/bin/
+/.classpath
+/.project
+/.settings/

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
 group = 'com.wiredforcode'
 archivesBaseName = 'gradle-spawn-plugin'
-version = '0.8.3'
+version = '0.8.4'
 
 apply plugin: 'idea'
 apply plugin: 'groovy'

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
 group = 'com.wiredforcode'
 archivesBaseName = 'gradle-spawn-plugin'
-version = '0.8.4'
+version = '0.8.5'
 
 apply plugin: 'idea'
 apply plugin: 'groovy'
@@ -34,7 +34,7 @@ distributions {
 
 ext {
     bintrayBaseUrl = 'https://api.bintray.com/maven'
-    bintrayUsername = 'vermeulen-mp'
+    bintrayUsername = 'gorky'
     bintrayRepository = 'gradle-plugins'
     bintrayPackage = 'gradle-spawn-plugin'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
 group = 'com.wiredforcode'
 archivesBaseName = 'gradle-spawn-plugin'
-version = '0.8.0'
+version = '0.8.2'
 
 apply plugin: 'idea'
 apply plugin: 'groovy'

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
 group = 'com.wiredforcode'
 archivesBaseName = 'gradle-spawn-plugin'
-version = '0.8.2'
+version = '0.8.3'
 
 apply plugin: 'idea'
 apply plugin: 'groovy'

--- a/src/main/groovy/com/wiredforcode/gradle/spawn/DefaultSpawnTask.groovy
+++ b/src/main/groovy/com/wiredforcode/gradle/spawn/DefaultSpawnTask.groovy
@@ -5,6 +5,11 @@ import org.gradle.api.DefaultTask
 class DefaultSpawnTask extends DefaultTask {
     String pidLockFileName = '.pid.lock'
     String directory = '.'
+    /**
+     * Time to wait for process to start/finish in seconds.
+     */
+    int timeout
+    
 
     File getPidFile() {
         return new File(directory, pidLockFileName)

--- a/src/main/groovy/com/wiredforcode/gradle/spawn/KillProcessTask.groovy
+++ b/src/main/groovy/com/wiredforcode/gradle/spawn/KillProcessTask.groovy
@@ -1,5 +1,7 @@
 package com.wiredforcode.gradle.spawn
 
+import java.util.concurrent.TimeUnit
+
 import org.gradle.api.tasks.TaskAction
 
 class KillProcessTask extends DefaultSpawnTask {
@@ -15,9 +17,24 @@ class KillProcessTask extends DefaultSpawnTask {
         def process = "kill $pid".execute()
 
         try {
-            process.waitFor()
+            if (timeout <= 0){
+                process.waitFor()
+            } else {
+                killWithTimeOut(process, pid)
+            }
         } finally {
             pidFile.delete()
         }
     }
+    
+    void killWithTimeOut(Process process, String pid){
+      boolean success = process.waitFor(timeout, TimeUnit.SECONDS)
+      if (!success){
+        logger.info "Soft stop timed out, executing 'kill -s 9 ${pid}"
+        def hardKillProcess = "kill -s 9 $pid".execute()
+        hardKillProcess.waitFor()
+      }
+    }
+    
+    
 }

--- a/src/main/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTask.groovy
+++ b/src/main/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTask.groovy
@@ -7,6 +7,12 @@ import org.gradle.api.tasks.TaskAction
 class SpawnProcessTask extends DefaultSpawnTask {
     String command
     String ready
+    /**
+     * If set, do NOT abort reading and close the pipe from the process stdout.  There
+     * are applications that will pick this up as a "Shutdown" signal.  Instead, continue
+     * "siphoning" or reading from the InputStream, but just "chuck" the data.
+     */
+    boolean siphon
     List<Closure> outputActions = new ArrayList<Closure>()
 
     @Input
@@ -114,12 +120,6 @@ class SpawnProcessTask extends DefaultSpawnTask {
     
     class ReaderWorker {
       boolean isReady = false
-      /**
-       * If set, do NOT abort reading and close the pipe from the process stdout.  There
-       * are applications that will pick this up as a "Shutdown" signal.  Instead, continue
-       * "siphoning" or reading from the InputStream, but just "chuck" the data.
-       */
-      boolean siphon
       Thread waiter
       Exception e;
       

--- a/src/main/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTask.groovy
+++ b/src/main/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTask.groovy
@@ -139,7 +139,6 @@ class SpawnProcessTask extends DefaultSpawnTask {
               //This applies to golang based code specifically
               if (siphon && isReady){
                 //done processing
-                logger.quiet currentThread.name + ':' + line
                 continue;
               }
               logger.quiet line

--- a/src/test/groovy/com/wiredforcode/gradle/spawn/KillProcessTaskSpec.groovy
+++ b/src/test/groovy/com/wiredforcode/gradle/spawn/KillProcessTaskSpec.groovy
@@ -105,4 +105,76 @@ class KillProcessTaskSpec extends Specification {
         then:
         killTask.pidLockFileName == '.new.pid.lock'
     }
+    
+    void "should kill a process with timeout set to long"() {
+        println "should kill a process with timeout set to long"
+        given:
+        def directoryPath = directory.toString()
+        def processSource = new File("src/test/resources/process.sh")
+        def process = new File(directory, "process.sh")
+        process << processSource.text
+        process.setExecutable(true)
+
+        and:
+        spawnTask.command = "./process.sh"
+        spawnTask.ready = "It is done..."
+        spawnTask.directory = directoryPath
+
+        and:
+        killTask.directory = directoryPath
+        killTask.timeout = 30
+
+        when:
+        spawnTask.spawn()
+        def lockFile = spawnTask.pidFile
+
+        then:
+        lockFile.exists()
+
+        when:
+        killTask.kill()
+
+        then:
+        !lockFile.exists()
+
+        cleanup:
+        assert directory.deleteDir()
+        killTask.timeout = 0
+    }
+    
+    void "should kill a process with timeout set to short"() {
+        println "should kill a process with timeout set to short"
+        given:
+        def directoryPath = directory.toString()
+        def processSource = new File("src/test/resources/process.sh")
+        def process = new File(directory, "process.sh")
+        process << processSource.text
+        process.setExecutable(true)
+
+        and:
+        spawnTask.command = "./process.sh"
+        spawnTask.ready = "It is done..."
+        spawnTask.directory = directoryPath
+
+        and:
+        killTask.directory = directoryPath
+        killTask.timeout = 1
+
+        when:
+        spawnTask.spawn()
+        def lockFile = spawnTask.pidFile
+
+        then:
+        lockFile.exists()
+
+        when:
+        killTask.kill()
+
+        then:
+        !lockFile.exists()
+
+        cleanup:
+        assert directory.deleteDir()
+        killTask.timeout = 0
+    }
 }

--- a/src/test/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTaskSpec.groovy
+++ b/src/test/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTaskSpec.groovy
@@ -213,10 +213,13 @@ class SpawnProcessTaskSpec extends Specification {
 
       then:
       def e = thrown(GradleException)
-      e.message == "Process failed to finish starting before timeout"
+      e.message == "Process failed to finish starting before timeout 7sec"
 
       and:
       !task.getPidFile().exists()
+      
+      cleanup:
+      task.timeout = 0
     }
 
     private void setExecutableProcess(String processFile) {

--- a/src/test/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTaskSpec.groovy
+++ b/src/test/groovy/com/wiredforcode/gradle/spawn/SpawnProcessTaskSpec.groovy
@@ -145,6 +145,7 @@ class SpawnProcessTaskSpec extends Specification {
         task.directory == directory.toString()
     }
 
+    //KABOOM!
     void "should not write the pid lock file if the process exits abnormally"() {
         given:
         def command = './exitAbnormally.sh'


### PR DESCRIPTION
**Fixes:**
- Background Process Hangs When There's Too Much Unprocessed Output.  See https://github.com/marc0der/gradle-spawn-plugin/issues/30
-  https://www.securecoding.cert.org/confluence/display/java/FIO07-J.+Do+not+let+external+processes+block+on+IO+buffers

**Enhancements**
- timeout: Allows a timeout to be set for when a process should be started/stopped
- siphon: Some processes will react to stdout being closed as a "Stop/Terminate" signal.  Setting this property will allow for the Spawn thread to continue running and pulling stdout after a "Ready Match".  This is useful in case there are other long running processes being run/launched by Gradle.

**Possible fixes for:**
Process does not continue #29
https://github.com/marc0der/gradle-spawn-plugin/issues/29
Spawn doesn't catch failed tasks
https://github.com/marc0der/gradle-spawn-plugin/issues/8

Available to use for testing/etc from https://bintray.com/gorky/gradle-plugins/gradle-spawn-plugin.

Released under the original Apache 2.0 license.
